### PR TITLE
19: feat(meetings): implement filters for meetings with search, statu…

### DIFF
--- a/src/app/(dashboard)/meetings/page.tsx
+++ b/src/app/(dashboard)/meetings/page.tsx
@@ -1,18 +1,25 @@
 import { getQueryClient, trpc } from "@/trpc/server";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { Suspense } from "react";
+import type { SearchParams } from "nuqs/server";
 import { ErrorBoundary } from "react-error-boundary";
 import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { loadSearchParams } from "@/modules/meetings/params";
 import { MeetingsListHeader } from "@/modules/meetings/ui/components/meetings-list-header"; 
 import {  
     MeetingsViewError, 
     MeetingsViewLoading } from "./ui/views/meetings-view";
 import { MeetingsView } from "@/modules/meetings/ui/views/meetings-view";
 
-const Page = async() => {
+
+interface Props {
+    searchParams: Promise<SearchParams>;
+}
+const Page = async({searchParams}:Props) => {
+    const filters = await loadSearchParams(searchParams);
     const session = await auth.api.getSession({
         headers: await headers(),
       });
@@ -22,7 +29,9 @@ const Page = async() => {
       }
     const queryClient = getQueryClient();
     void queryClient.prefetchQuery(
-        trpc.meetings.getMany.queryOptions({})
+        trpc.meetings.getMany.queryOptions({
+            ...filters,
+        })
     )
     return (
         <>

--- a/src/app/(dashboard)/meetings/ui/views/meetings-view.tsx
+++ b/src/app/(dashboard)/meetings/ui/views/meetings-view.tsx
@@ -1,16 +1,45 @@
 "use client";
 
+import { DataTable } from "@/components/data-table";
+import { EmptyState } from "@/components/empty-state";
 import { ErrorState } from "@/components/error-state";
 import { LoadingState } from "@/components/loading-state";
+import { DataPagination } from "@/modules/agents/ui/components/data-pagination";
+import { useMeetingsFilters } from "@/modules/meetings/hooks/use-meetings-filters";
+import { columns } from "@/modules/meetings/ui/components/columns";
 import { useTRPC } from "@/trpc/client";
-import {  useSuspenseQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { useRouter } from "next/router";
 
 export const MeetingsView = () => {
+    
     const trpc = useTRPC();
-    const { data } = useSuspenseQuery(trpc.meetings.getMany.queryOptions({}))
+    const router = useRouter();
+    const [filters, setFilters] = useMeetingsFilters();
+    const { data } = useSuspenseQuery(trpc.meetings.getMany.queryOptions({
+        ...filters,  
+    }))
+
+
     return (
-        <div>
-            {JSON.stringify(data)}   
+        <div className="flex-1 pb-4 px-4 md:px-8 flex flex-col gap-y-4">
+            <DataTable 
+            data={data.items} 
+            columns={columns} 
+            onRowClick={(row) => router.push(`/meetings/${row.id}`)}/>
+            <DataPagination
+                page={filters.page}
+                totalPages={data.totalPages}
+                onPageChange={(page) => setFilters({
+                    page,
+                })}
+            />
+              {data.items.length === 0 && (
+                <EmptyState
+                    title="No Meetings Found"
+                    description="You can create a new meeting by clicking the button below."
+                />
+              )}
         </div>
         
     );

--- a/src/components/command-select.tsx
+++ b/src/components/command-select.tsx
@@ -35,6 +35,13 @@ export const CommandSelect = ({
 }: Props) => {
     const [open, setOpen] = useState(false);
     const selectOption = options.find((option)=> option.value === value)
+
+    const handleOpenChange = (open: boolean) => {
+        onSearch?.("");
+        setOpen(open);
+    };
+
+
     return (
         <>
           <Button 
@@ -55,7 +62,7 @@ export const CommandSelect = ({
           <CommandResponsiveDialog
              shouldFilter={!onSearch}
              open={open}
-             onOpenChange={setOpen}
+             onOpenChange={handleOpenChange}
           >
             <CommandInput placeholder="search..." onValueChange={onSearch}/>
             <CommandList>

--- a/src/modules/agents/ui/components/agents-list-header.tsx
+++ b/src/modules/agents/ui/components/agents-list-header.tsx
@@ -8,6 +8,7 @@ import { NewAgentDialog } from "./new-agent-dialog";
 import { useAgentsFilters } from "../../hooks/use-agents-filters";
 import { AgentsSearchFilter } from "./agents-search-filter";
 import { DEFAULT_PAGE } from "@/constants";
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 
 export const AgensListHeader = () => {
   const [filters, setFilters] = useAgentsFilters();
@@ -34,15 +35,18 @@ export const AgensListHeader = () => {
             New Agent
           </Button>
         </div>
+        <ScrollArea>
         <div className="flex item-center gap-x-2 p-1">
           <AgentsSearchFilter/>
           {isAnyFilterModified && (
-            <Button variant="outline" size="sm" onClick={onClearFilter} >
+            <Button variant="outline" size="sm" onClick={onClearFilter } >
               <XCircleIcon/>
               Clear
             </Button>
           )}
         </div>
+        <ScrollBar orientation="horizontal" />
+        </ScrollArea>
       </div>
     </>
   );

--- a/src/modules/meetings/hooks/use-meetings-filters.ts
+++ b/src/modules/meetings/hooks/use-meetings-filters.ts
@@ -1,0 +1,14 @@
+import { DEFAULT_PAGE } from "@/constants"
+
+import { parseAsInteger, parseAsString, useQueryStates, parseAsStringEnum } from "nuqs";
+
+import { MeetingStatus } from "../types";
+export const useMeetingsFilters = () => {
+    return useQueryStates ({
+        search: parseAsString.withDefault("").withOptions({ clearOnDefault: true}),
+        page: parseAsInteger.withDefault(DEFAULT_PAGE).withOptions({ clearOnDefault: true}),
+        status: parseAsStringEnum(Object.values(MeetingStatus)),
+        agentId: parseAsString.withDefault("").withOptions({ clearOnDefault: true}),
+    });
+};
+

--- a/src/modules/meetings/params.ts
+++ b/src/modules/meetings/params.ts
@@ -1,0 +1,15 @@
+import { createLoader, parseAsInteger, parseAsString, parseAsStringEnum } from "nuqs/server";
+
+import { DEFAULT_PAGE } from "@/constants";
+
+import { MeetingStatus } from "./types";
+
+export const filtersSearchParams = {
+    search: parseAsString.withDefault("").withOptions({ clearOnDefault: true}),
+    page: parseAsInteger.withDefault(DEFAULT_PAGE).withOptions({ clearOnDefault: true}),
+   status: parseAsStringEnum(Object.values(MeetingStatus)),
+    agentId: parseAsString.withDefault("").withOptions({ clearOnDefault: true})
+
+}
+
+export const loadSearchParams = createLoader(filtersSearchParams); 

--- a/src/modules/meetings/server/procedures.ts
+++ b/src/modules/meetings/server/procedures.ts
@@ -15,6 +15,7 @@ import {
   MAX_PAGE_SIZE,
   MIN_PAGE_SIZE,
 } from "@/constants";
+import { MeetingStatus } from "../types";
 
 
 export const meetingsRouter = createTRPCRouter({
@@ -90,11 +91,21 @@ export const meetingsRouter = createTRPCRouter({
           .max(MAX_PAGE_SIZE)
           .default(DEFAULT_PAGE_SIZE),
         search: z.string().nullish(),
+        agentId : z.string().nullish(),
+        status: z
+          .enum([
+            MeetingStatus.Upcoming,
+            MeetingStatus.Active,
+            MeetingStatus.Completed,
+            MeetingStatus.Cancelled,
+            MeetingStatus.Processing, 
+          ])
+          .nullish(),
       })
     )
 
     .query(async ({ ctx, input }) => {
-      const { search, page, pageSize } = input;
+      const { search, page, pageSize, agentId, status } = input;
       const data = await db
         .select({
           ...getTableColumns(meetings),
@@ -108,7 +119,9 @@ export const meetingsRouter = createTRPCRouter({
         .where(
           and(
             eq(meetings.userId, ctx.auth.user.id),
-            search ? ilike(meetings.name, `%${search}%`) : undefined
+            search ? ilike(meetings.name, `%${search}%`) : undefined,
+            agentId ? eq(meetings.agentId, agentId) : undefined,
+            status ? eq(meetings.status, status) : undefined
           )
         )
         .orderBy(desc(meetings.createdAt), desc(meetings.id))

--- a/src/modules/meetings/types.ts
+++ b/src/modules/meetings/types.ts
@@ -4,3 +4,10 @@ import type { AppRouter } from "@/trpc/routers/_app";
 
 export type MeetingGetOne = inferRouterOutputs<AppRouter>["meetings" ]["getOne"];
 export type MeetingGetMany = inferRouterOutputs<AppRouter>["meetings"]["getMany"]["items"];
+export enum MeetingStatus {
+    Upcoming = "upcoming",
+    Active = "active",
+    Completed = "completed",
+    Cancelled = "cancelled",
+    Processing = "processing",  
+}

--- a/src/modules/meetings/ui/components/agent-id-filter.tsx
+++ b/src/modules/meetings/ui/components/agent-id-filter.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { useTRPC } from "@/trpc/client";
+import { CommandSelect } from "@/components/command-select";
+import { GeneratedAvatar } from "@/components/generated-avatar";
+
+import { useMeetingsFilters } from "../../hooks/use-meetings-filters";
+
+export const AgentIdFilter = () => {
+    const [filters, setFilters] = useMeetingsFilters();
+
+    const trpc = useTRPC();
+
+    const [agentSearch, setAgentSearch] = useState("");
+    const { data } = useQuery(
+        trpc.agent.getMany.queryOptions({
+            pageSize: 100,
+            search: agentSearch,
+        }),
+    );
+
+    return (
+        <CommandSelect
+          className="h-9"
+            placeholder="Filter by Agent"
+            options={(data?.items ?? []).map((agent) => ({ id: agent.id, 
+            value: agent.id, 
+            children: (
+                <div className="flex items-center gap-x-2">
+                    <GeneratedAvatar
+                        seed={agent.name}
+                        variant="botttsNetural"
+                        className="size-4"
+                    />
+                    {agent.name}
+                </div>
+            ),
+            }))}
+            onSelect={(value) => setFilters({ agentId: value})}
+            onSearch={setAgentSearch}
+            value={filters.agentId ?? ""}
+        />
+    )
+}

--- a/src/modules/meetings/ui/components/meetings-list-header.tsx
+++ b/src/modules/meetings/ui/components/meetings-list-header.tsx
@@ -1,15 +1,34 @@
 "use client";
 import { useState } from "react";
-import { PlusIcon } from "lucide-react";
+import { PlusIcon, XCircleIcon  } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { NewMeetingDialog } from "./new-meeting-dialog";
+import { MeetingsSearchFilter } from "./meetings-search-filter";
+import { StatusFilter } from "./status-filter";
+import { AgentIdFilter } from "./agent-id-filter";
+import { useMeetingsFilters } from "../../hooks/use-meetings-filters";
+import { ScrollArea } from "@radix-ui/react-scroll-area";
+import { ScrollBar } from "@/components/ui/scroll-area";
+import { DEFAULT_PAGE } from "@/constants";
 
 
 
 
 export const MeetingsListHeader = () => { 
+  const [filters, setFilters] = useMeetingsFilters();
   const [ isDialogOpen, setIsDialogOpen ] = useState(false);
+
+  const isAnyFilterModified = !!filters.status || !!filters.search || !!filters.agentId;
+
+  const onClearFilters = () => {
+    setFilters({
+      status: null,
+      search: "",
+      agentId: "",
+      page: DEFAULT_PAGE,
+    });
+  };
 
 
   return (
@@ -25,9 +44,20 @@ export const MeetingsListHeader = () => {
             New Meeting
           </Button>
         </div>
+        <ScrollArea>
         <div className="flex item-center gap-x-2 p-1">
-            TODO: Filters
+            <MeetingsSearchFilter />
+            <StatusFilter/> 
+            <AgentIdFilter />
+            {isAnyFilterModified && (
+              <Button variant="outline" onClick={onClearFilters}>
+                <XCircleIcon className="size-4" />
+                Clear Filters
+              </Button>
+            )}
         </div>
+        <ScrollBar orientation="horizontal"/> 
+        </ScrollArea>
       </div>
     </>
   );

--- a/src/modules/meetings/ui/components/meetings-search-filter.tsx
+++ b/src/modules/meetings/ui/components/meetings-search-filter.tsx
@@ -1,0 +1,21 @@
+import { SearchIcon } from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+
+import { useMeetingsFilters } from "../../hooks/use-meetings-filters";
+
+export const MeetingsSearchFilter = () => {
+    const [filters, setFilters] = useMeetingsFilters();
+
+    return (
+        <div className="relative">
+            <Input
+                placeholder="Filter by name"
+                className="h-9 bg-white w-[200px] pl-7"
+                value={filters.search}
+                onChange={(e) => setFilters({ search: e.target.value })}
+            />
+            <SearchIcon className="size-4 absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"/>
+        </div>
+    )
+}

--- a/src/modules/meetings/ui/components/status-filter.tsx
+++ b/src/modules/meetings/ui/components/status-filter.tsx
@@ -1,0 +1,79 @@
+import {
+    CircleXIcon,
+    CircleCheckIcon,
+    ClockArrowUpIcon,
+    VideoIcon,
+    LoaderIcon,
+} from 'lucide-react';
+
+import { CommandSelect } from '@/components/command-select';
+
+import { MeetingStatus } from '../../types';
+import { useMeetingsFilters } from '../../hooks/use-meetings-filters';
+
+
+const options = [
+    {
+        id: MeetingStatus.Upcoming,
+        value: MeetingStatus.Upcoming,
+        children: (
+            <div className='flex items-center gap-x-2 capitalize'>
+                <ClockArrowUpIcon/>
+                {MeetingStatus.Upcoming}
+            </div>
+        )
+    },
+    {
+        id: MeetingStatus.Active,
+        value: MeetingStatus.Active,
+        children: (
+            <div className='flex items-center gap-x-2 capitalize'>
+                <VideoIcon/>
+                {MeetingStatus.Active}
+            </div>
+        )
+    }
+    ,
+    {
+        id: MeetingStatus.Completed,
+        value: MeetingStatus.Completed,
+        children: (
+            <div className='flex items-center gap-x-2 capitalize'>
+                <CircleCheckIcon/>
+                {MeetingStatus.Completed}
+            </div>
+        )
+    },
+    {
+        id: MeetingStatus.Cancelled,
+        value: MeetingStatus.Cancelled,
+        children: (
+            <div className='flex items-center gap-x-2 capitalize'>
+                <CircleXIcon/>
+                {MeetingStatus.Cancelled}
+            </div>
+        )
+    },
+    {
+        id: MeetingStatus.Processing,
+        value: MeetingStatus.Processing,
+        children: (
+            <div className='flex items-center gap-x-2 capitalize'>
+                <LoaderIcon/>
+                {MeetingStatus.Processing}
+            </div>
+        ),
+    },
+];
+export const StatusFilter = () => {
+    const [filters, setFilters] = useMeetingsFilters();
+    return (
+        <CommandSelect
+            placeholder='Filter by status'
+            className='h-9'
+            options={options}
+            onSelect={(value) => setFilters({ status: value as MeetingStatus})}
+            value={filters.status ?? ""}
+        />
+    );
+}


### PR DESCRIPTION
📝 Description:
This PR includes the complete implementation of the 19 Meetings Filters feature. The following tasks were addressed:

🎯 Backend Enhancements
Improved badge padding for better UI consistency ✅

Fixed command select filter reset behavior ✅

Modified meetings.getMany procedure to support new filter params ✅

Added NUQS filters integration ✅

Synced RSC filters with client-side filters ✅

💡 UI/UX Updates
Added UI components for the new filters ✅

Search Input ✅

Agent command select ✅

Pagination controls ✅

🔍 Other Tasks
Created, reviewed, and merged corresponding changes to ensure alignment across client and server ✅

📦 Checklist
 All new filters are implemented and tested

 Responsive and accessible UI for all filters

 Backend endpoints updated to support new logic

 Peer-reviewed and tested locally

 No breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced advanced filtering for meetings, allowing users to filter by search term, status, and agent.
  * Added a search bar and dropdown filters for meeting status and agent selection.
  * Implemented pagination controls for meetings list.
  * Added a "Clear Filters" button to reset all filters at once.
  * Enhanced empty state messaging when no meetings are found.

* **Improvements**
  * Meetings list now displays in a data table with improved layout and navigation.
  * Filter controls are now horizontally scrollable for better usability.
  * Selecting or clearing filters updates the meetings list dynamically.

* **Bug Fixes**
  * Clearing the search input when closing the command dialog for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->